### PR TITLE
chore(app): CLI nn model info + CI sanity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-sanity:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Xcode version
+        run: |
+          xcodebuild -version
+          sw_vers
+
+      - name: Build LlamaBridgeTest (Debug, no code signing)
+        run: |
+          set -euxo pipefail
+          xcodebuild -scheme LlamaBridgeTest \
+            -project "NoesisNoema.xcodeproj" \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            -derivedDataPath ci_build \
+            CODE_SIGNING_ALLOWED=NO \
+            build | cat
+
+      - name: Sanity: nn model info --dry-run
+        run: |
+          set -euxo pipefail
+          ./ci_build/Build/Products/Debug/LlamaBridgeTest model info jan-v1-4b --dry-run
+
+      - name: Run CLI tests
+        run: |
+          set -euxo pipefail
+          ./ci_build/Build/Products/Debug/LlamaBridgeTest model test


### PR DESCRIPTION
What
Add CLI command `nn model info <model_id>` options and enforce sanity checks in CI.

Why
Guarantee Registry functionality passes minimal checks before merging.

How
- CLI: add `--dry-run` (skip file hashing/model load) and `--trace` (decision logs) to `nn model info`
- AutotuneService: plumb `dryRun` so hashing is skipped and cache key uses 'nofile'
- Tests: add corrupted GGUF metadata error, M2 Pro autotune case (Apple Silicon presets)
- CI (pull_request): build LlamaBridgeTest (no codesign), run `nn model info jan-v1-4b --dry-run`, run CLI tests

DoD
- CI: `nn model info --dry-run` succeeds on macOS runner
- Tests: corrupted metadata error, unknown quantization fallback, Apple Silicon presets pass

Notes
- Changes are additive; default behavior unchanged unless flags are used.
- CI uses macos-latest and disables code signing for CLI target.
