### PR TITLE
fix: show citations on macOS; bypass answer cache so responses vary by model

### DIFF
--- a/NoesisNoema/Shared/ContentView.swift
+++ b/NoesisNoema/Shared/ContentView.swift
@@ -302,8 +302,13 @@ struct ContentView: View {
         isLoading = false
 
         // Build citations mapping from answer text and last retrieved chunks
-        let perParagraph = CitationExtractor.extractParagraphLabels(from: result)
+        var perParagraph = CitationExtractor.extractParagraphLabels(from: result)
         let chunks = ModelManager.shared.lastRetrievedChunks
+        // Fallback: if no labels found but we have sources, attach all sources to first paragraph
+        let hasAnyLabel = perParagraph.contains { !$0.isEmpty }
+        if !hasAnyLabel && !chunks.isEmpty {
+            perParagraph = [Array(1...chunks.count)]
+        }
         // Build catalog with 1-based index
         let catalog: [CitationInfo] = chunks.enumerated().map { (i, ch) in
             CitationInfo(index: i + 1, title: ch.sourceTitle, path: ch.sourcePath, page: ch.page)

--- a/NoesisNoema/Shared/ModelManager.swift
+++ b/NoesisNoema/Shared/ModelManager.swift
@@ -288,13 +288,8 @@ class ModelManager {
 
     /// Generates an answer to a question using the LLM model (asynchronous)
     func generateAsyncAnswer(question: String) async -> String {
-        // 0) Semantic Answer Cache fast-path (with verification)
-        if let hit = SemanticAnswerCache.shared.lookup(question: question, embedder: self.currentEmbeddingModel, store: VectorStore.shared, topK: 3, trace: false) {
-            // Update lastRetrievedChunks for citation UI even on cache hit
-            self.lastRetrievedChunks = hit.sources
-            return hit.answer
-        }
-        // 1) RAG文脈を構築（従来フロー）
+        // キャッシュは使用しない: 毎回最新のRAGとモデルで生成する
+        // 1) RAG文脈を構築
         let embedding = self.currentEmbeddingModel.embed(text: question)
         let topChunks = VectorStore.shared.findRelevant(queryEmbedding: embedding, topK: 6)
         self.lastRetrievedChunks = topChunks


### PR DESCRIPTION
Summary\n- Fix citations not showing on macOS by building ParagraphCitations from lastRetrievedChunks with fallback labels when the model doesn't emit [n].\n- Disable SemanticAnswerCache lookup so answers are freshly generated per model/run (no sticky answers).\n\nDetails\n- ContentView.askRAG: add fallback [1..k] labels and always build catalog from lastRetrievedChunks.\n- ModelManager.generateAsyncAnswer: always run RAG + LLM, do not use cache.\n\nBuild\n- Verified NoesisNoema (macOS) builds locally in Debug (xcodebuild).\n\nMerge policy\n- Please squash-merge to main.